### PR TITLE
System.out shouldn't be closed when closing Report because following …

### DIFF
--- a/src/main/java/org/ltr4l/tools/Report.java
+++ b/src/main/java/org/ltr4l/tools/Report.java
@@ -69,7 +69,7 @@ public class Report {
   }
 
   public void close(){
-    if(ps != null) ps.close();
+    if(ps != null && ps != System.out) ps.close();
   }
 
   public static String getReportFile(Config config){


### PR DESCRIPTION
…messages on stdout cannot be seen