### PR TITLE
Added LIB_DIR back to ivy-jars.properties. This closes #264

### DIFF
--- a/ivy-jars.properties
+++ b/ivy-jars.properties
@@ -45,6 +45,7 @@ ivy.jar.httpcomponents-core.name=httpcore
 ivy.jar.httpcomponents-client.rev=4.5.5
 ivy.jar.httpcomponents-client.name=httpclient
 
+LIB_DIR=lib
 JARS_JACKSON=${LIB_DIR}/${ivy.jar.jackson-core.name}-${ivy.jar.jackson.rev}.jar ${LIB_DIR}/${ivy.jar.jackson-databind.name}-${ivy.jar.jackson.rev}.jar ${LIB_DIR}/${ivy.jar.jackson-annotations.name}-${ivy.jar.jackson.rev}.jar
 JARS_COMMONS_CLI=${LIB_DIR}/${ivy.jar.commons-cli.name}-${ivy.jar.commons-cli.rev}.jar
 


### PR DESCRIPTION
It was removed in commit 5a1e411ebf20afa0befd77cc4ac2fec52cafd516

train and predict scripts should work again now.